### PR TITLE
Remove ffaker

### DIFF
--- a/practices/testing.md
+++ b/practices/testing.md
@@ -171,8 +171,6 @@
 
 - Use [factory_girl_rails](https://github.com/thoughtbot/factory_girl_rails) over fixtures.
 
-- Use [ffaker](https://github.com/EmmanuelOga/ffaker) for data generation.
-
 - In your `rails_helper`, always set `config.use_transactional_fixtures` to `false`
 
 - External HTTP requests are slow. Always mock them or use gems like [vcr](https://github.com/vcr/vcr) and [WebMock](https://github.com/bblimke/webmock).


### PR DESCRIPTION
Do we really need ffaker in tests? It introduces a non-deterministic factor in testing that you can do without. Case in point:

- https://github.com/EmmanuelOga/ffaker/pull/181

It's great to use ffaker for seed data though.