### PR TITLE
Changes serve_static_assets to serve_static_files

### DIFF
--- a/workflow/heroku.md
+++ b/workflow/heroku.md
@@ -34,7 +34,7 @@ ruby "2.1.2"
 ```
 Set static asset serving at `config/application.rb`
 ```
-config.serve_static_assets = true
+config.serve_static_files = true
 ```
 It is expected that credentials/keys are set in your `secrets.yml`(which is included in the repo), just make sure the these are appropriately set within `production: ` block as well
 ```


### PR DESCRIPTION
serve_static_assets is already deprecated based on heroku logs when deploying.

> DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed to `config.serve_static_files` to clarify its role (it merely enables serving everything in the `public` folder and is unrelated to the asset pipeline).