### PR TITLE
testing: refine notes on --profile

### DIFF
--- a/practices/testing.md
+++ b/practices/testing.md
@@ -34,11 +34,17 @@
   --format=doc
   ```
 
-- Running specs with the `--profile` or `-p` option will display the top ten slowest examples. It also accepts a number argument.
+- Running specs with the `--profile` or `-p` option will display the top ten slowest examples. It also accepts a number argument. Run this in your CI, but don't place it in `.rspec`.
 
   ```
   # Displays the 5 slowest examples
   > rspec spec/models/user_spec.rb -p 5
+  ```
+  
+- Add `.rspec-local` to your project's `.gitignore` file. This will allow individual developers to customize their own default rspec parameters.
+
+  ```sh
+  echo .rspec-local >> .gitignore
   ```
 
 - Use [shared_examples](https://www.relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples) when possible.


### PR DESCRIPTION
@victorsolis what do you think? putting it in .rspec is kind of useless for bigger projects where you only run a portion of the specs (but not all). you should put it in .rspec-local if you like.