### PR TITLE
testing: remove capybara negatives

### DIFF
--- a/practices/testing.md
+++ b/practices/testing.md
@@ -363,15 +363,6 @@ Don't.
 
 - Helper methods inside `feature` blocks or within the spec file is allowed.
 
-- Always use the Capybara version for negations.
-
-  ```ruby
-  expect(page).to have_no_content user.name
-
-  # AVOID
-  expect(page).to_not have_content user.name
-  ```
-
 - Limit the usage of the `js: true` tag only to blocks that have javascript interaction.
 
 - Use [teaspoon](https://github.com/modeset/teaspoon) for unit javascript testing.


### PR DESCRIPTION
> Capybara's Rspec matchers, however, are smart enough to handle either form. The two following statements are functionally equivalent:
>
> ```rb
> expect(page).not_to have_xpath('a')
> expect(page).to have_no_xpath('a')
> ```

https://github.com/jnicklas/capybara